### PR TITLE
Upgrade posthtml-render

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Prism = require('prismjs');
-const render = require('posthtml-render').default;
+const {render} = require('posthtml-render');
 const loadLanguages = require('prismjs/components/');
 
 function createPrismPlugin(options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,14 @@
         "np": "^7.4.0",
         "nyc": "^15.0.0",
         "posthtml": "^0.16.4",
-        "posthtml-render": "^2.0.6",
+        "posthtml-render": "^3.0.0",
         "xo": "^0.39.1"
       },
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "posthtml-render": "^3.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -9020,18 +9023,6 @@
       }
     },
     "node_modules/posthtml-render": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-2.0.6.tgz",
-      "integrity": "sha512-AvjM4yfEtjhbpZdtLOWfnezgojEtgeejSxrjTAvfr5phXjPcZQyB5QiOvYeU+rrTF0u+eqqlJrs8HS3nrPexGQ==",
-      "dev": true,
-      "dependencies": {
-        "is-json": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/posthtml/node_modules/posthtml-render": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
       "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
@@ -18723,17 +18714,6 @@
       "requires": {
         "posthtml-parser": "^0.10.0",
         "posthtml-render": "^3.0.0"
-      },
-      "dependencies": {
-        "posthtml-render": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-          "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-          "dev": true,
-          "requires": {
-            "is-json": "^2.0.1"
-          }
-        }
       }
     },
     "posthtml-parser": {
@@ -18746,9 +18726,9 @@
       }
     },
     "posthtml-render": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-2.0.6.tgz",
-      "integrity": "sha512-AvjM4yfEtjhbpZdtLOWfnezgojEtgeejSxrjTAvfr5phXjPcZQyB5QiOvYeU+rrTF0u+eqqlJrs8HS3nrPexGQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
       "dev": true,
       "requires": {
         "is-json": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
     "np": "^7.4.0",
     "nyc": "^15.0.0",
     "posthtml": "^0.16.4",
-    "posthtml-render": "^2.0.6",
+    "posthtml-render": "^3.0.0",
     "xo": "^0.39.1"
+  },
+  "peerDependencies": {
+    "posthtml-render": "^3.0.0"
   }
 }


### PR DESCRIPTION
The current version of posthtml-prism doesn't work with the latest posthtml-render, which changed the API from a default export to a named export. I upgraded the dev dependency here and also added a peer dependency requirement so the versions get checked by package managers.